### PR TITLE
feat: add sponsorship support and git flow documentation

### DIFF
--- a/.cursor/rules/coding-standards.mdc
+++ b/.cursor/rules/coding-standards.mdc
@@ -54,7 +54,62 @@ These rules are enforced by Prettier -- do not deviate:
 - `@typescript-eslint/no-unused-vars`: warn (ignored if prefixed with `_`)
 - `no-console`: warn -- avoid `console.log` in production code (stripped in prod builds)
 
-## Git Conventions
+## Git Branching Strategy (Git Flow)
 
-- Branch names: `feat/description`, `fix/description`, `refactor/description`, `docs/description`
-- Commit messages: `feat: add feature`, `fix: resolve bug`, `refactor: extract utility`
+### Primary Branches
+
+| Branch | Purpose | Merges Into |
+|--------|---------|-------------|
+| `main` | Production-ready releases. Always stable and tagged. | -- |
+| `develop` | Integration branch for features. All new work starts here. | `main` (via `release/*`) |
+
+### Supporting Branches
+
+| Prefix | Purpose | Branch From | Merge Into |
+|--------|---------|-------------|------------|
+| `feat/` | New features | `develop` | `develop` |
+| `fix/` | Bug fixes (non-urgent) | `develop` | `develop` |
+| `refactor/` | Code refactoring | `develop` | `develop` |
+| `docs/` | Documentation changes | `develop` | `develop` |
+| `release/vX.Y.Z` | Release preparation and final QA | `develop` | `main` + `develop` |
+| `hotfix/` | Urgent production fixes | `main` | `main` + `develop` |
+
+### Branch Naming
+
+- Always use lowercase with hyphens: `feat/voice-trigger-editing`
+- Be descriptive but concise: `fix/audio-recording-crash`, not `fix/bug`
+- Include issue number when applicable: `feat/123-custom-actions`
+
+### Workflow
+
+1. Create feature branch from `develop`: `git checkout -b feat/my-feature develop`
+2. Commit with conventional messages (see below)
+3. Open a PR targeting `develop`
+4. After review and CI pass, merge into `develop`
+5. When ready for release, create `release/vX.Y.Z` from `develop`
+6. After QA on release branch, merge into `main` and tag: `git tag vX.Y.Z`
+7. Merge release back into `develop` to capture any last-minute fixes
+8. For urgent production bugs, branch `hotfix/` from `main`, fix, then merge into both `main` and `develop`
+
+### Commit Messages (Conventional Commits)
+
+Format: `type: short description`
+
+| Type | When to Use |
+|------|-------------|
+| `feat` | New feature: `feat: add voice trigger editing` |
+| `fix` | Bug fix: `fix: resolve audio recording crash on Windows` |
+| `refactor` | Restructuring without behavior change: `refactor: extract audio utility` |
+| `docs` | Documentation only: `docs: update API key setup guide` |
+| `chore` | Tooling, deps, config: `chore: bump electron to v33.2` |
+| `style` | Formatting, whitespace: `style: fix indentation in ai-router` |
+| `test` | Adding or fixing tests: `test: add unit tests for formatting utils` |
+| `perf` | Performance improvement: `perf: optimize overlay window preloading` |
+
+### Rules
+
+- Never force-push to `main` or `develop`
+- Always open a PR -- no direct pushes to `main` or `develop`
+- Run `npm run typecheck && npm run lint` before pushing
+- Delete feature branches after merging
+- Tag every production release on `main`: `vX.Y.Z`

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: zeyadelosherey

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,11 +9,18 @@ Brief description of the changes in this PR.
 
 ## Type of Change
 
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Refactoring (no functional changes)
-- [ ] Documentation update
+- [ ] Bug fix (`fix/`)
+- [ ] New feature (`feat/`)
+- [ ] Refactoring (`refactor/`)
+- [ ] Documentation (`docs/`)
+- [ ] Hotfix (`hotfix/`)
+- [ ] Release (`release/`)
 - [ ] Other (describe below)
+
+## Target Branch
+
+- [ ] `develop` (features, fixes, refactors, docs)
+- [ ] `main` (hotfixes and releases only)
 
 ## Testing
 
@@ -25,11 +32,13 @@ Describe how you tested the changes:
 
 ## Checklist
 
+- [ ] Branch follows naming convention (`feat/`, `fix/`, `refactor/`, `docs/`, `hotfix/`, `release/`)
+- [ ] Commit messages follow conventional format (`type: description`)
 - [ ] My code follows the project coding standards
 - [ ] I have run `npm run typecheck` with no errors
 - [ ] I have run `npm run lint` with no errors
 - [ ] I have updated documentation if needed
-- [ ] I have added translations for new user-facing strings
+- [ ] I have added translations for new user-facing strings (all 6 locales)
 
 ## Screenshots
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,134 @@
+# Copilot Instructions -- TapWisper Desktop
+
+This file provides context for GitHub Copilot and GPT-based coding assistants.
+
+## Project Summary
+
+TapWisper Desktop is an open-source, system-wide voice dictation tool with AI, built with **Electron 33**, **React 19**, **TypeScript 5.7**, and **Tailwind CSS 3.4**. It supports multiple AI providers (Gemini, Together AI, OpenAI, Claude) and voice providers (Together Whisper, Soniox).
+
+## Architecture
+
+Three Electron processes:
+
+- **Main** (`src/main/`) -- system tray, global shortcuts, window management, IPC handlers, clipboard, audio recording, permission checking, SQLite database, config store
+- **Preload** (`src/preload/`) -- context bridge exposing `window.tapwisper.*` API to the renderer
+- **Renderer** (`src/renderer/`) -- React UI with Tailwind CSS, Zustand state, Framer Motion animations
+
+Path alias: `@/` maps to `src/renderer/`.
+
+## Coding Conventions
+
+### File Naming
+
+- **kebab-case** for all files: `my-component.tsx`, `use-audio.ts`
+- **PascalCase** for component exports: `export function MyComponent()`
+- **camelCase** for hooks, utilities, variables: `useAudio`, `formatDuration`
+
+### TypeScript
+
+- Never use `any` -- use proper type definitions
+- `interface` for object shapes, `type` for unions and intersections
+- Shared types in `src/renderer/models/` or `src/renderer/types/`
+- Prefix unused parameters with `_`
+
+### React
+
+- Functional components only -- no class components
+- Extract reusable logic into hooks in `src/renderer/hooks/`
+- Use `React.lazy()` for overlay components
+- Hash-based routing for multi-window rendering
+
+### Styling
+
+- Tailwind CSS utility classes only -- no custom CSS unless necessary
+- Theme colors via CSS variables from `src/renderer/styles/globals.css`
+
+### Internationalization
+
+- All user-facing strings use `useTranslation()` from react-i18next
+- Add translations to all 6 locale files in `src/renderer/i18n/` (en, ar, de, es, fr, it)
+
+### Formatting (Prettier)
+
+- No semicolons
+- Single quotes
+- No trailing commas
+- 100 character print width
+- 2-space indentation
+- LF line endings
+- Always use parentheses around arrow function parameters
+
+### Linting (ESLint)
+
+- `@typescript-eslint/no-explicit-any`: warn
+- `@typescript-eslint/no-unused-vars`: warn (ignored with `_` prefix)
+- `no-console`: warn
+
+## Git Branching Strategy (Git Flow)
+
+### Primary Branches
+
+| Branch | Purpose |
+|--------|---------|
+| `main` | Production-ready releases. Always stable and tagged with `vX.Y.Z`. |
+| `develop` | Integration branch. All feature work branches from here and merges back here. |
+
+### Supporting Branches
+
+| Prefix | Branch From | Merge Into | Example |
+|--------|-------------|------------|---------|
+| `feat/` | `develop` | `develop` | `feat/voice-trigger-editing` |
+| `fix/` | `develop` | `develop` | `fix/audio-recording-crash` |
+| `refactor/` | `develop` | `develop` | `refactor/extract-audio-utility` |
+| `docs/` | `develop` | `develop` | `docs/update-api-guide` |
+| `release/vX.Y.Z` | `develop` | `main` + `develop` | `release/v1.2.0` |
+| `hotfix/` | `main` | `main` + `develop` | `hotfix/critical-crash` |
+
+### Workflow
+
+1. Create feature branch from `develop`: `git checkout -b feat/my-feature develop`
+2. Commit with conventional messages (see below)
+3. Open a PR targeting `develop`
+4. After review and CI pass, merge into `develop`
+5. For releases: create `release/vX.Y.Z` from `develop`, QA, merge into `main`, tag, merge back to `develop`
+6. For hotfixes: branch from `main`, fix, merge into both `main` and `develop`
+
+### Commit Message Format
+
+Format: `type: short description`
+
+| Type | When to Use |
+|------|-------------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `refactor` | Restructuring without behavior change |
+| `docs` | Documentation only |
+| `chore` | Tooling, dependencies, config |
+| `style` | Formatting, whitespace |
+| `test` | Adding or fixing tests |
+| `perf` | Performance improvement |
+
+### Rules
+
+- Never force-push to `main` or `develop`
+- Always open a PR -- no direct pushes to `main` or `develop`
+- Run `npm run typecheck && npm run lint` before pushing
+- Delete feature branches after merging
+- Tag every production release on `main`: `vX.Y.Z`
+
+## Key Patterns
+
+- **IPC**: All renderer-to-main communication goes through `window.tapwisper.*` (defined in preload). Never use `ipcRenderer` directly.
+- **AI Router**: `src/renderer/services/ai-router.ts` routes requests to the configured LLM/voice provider.
+- **Multi-Window**: 5 windows total -- main settings + 4 overlay windows (recording pill, pinned panel, command popup, AI panel). Overlays are pre-warmed.
+- **State**: Zustand stores in `src/renderer/store/`. Config lives in electron-store via `window.tapwisper.store.*`.
+
+## Common Pitfalls
+
+- Do not use `any` -- the linter will warn
+- Do not leave `console.log` -- stripped in production and linted as warning
+- Always add i18n translations to all 6 locale files
+- Overlay windows are frameless and transparent -- test visual changes carefully
+- API keys are stored in electron-store; never log or expose them
+- `better-sqlite3` is a native module -- it is externalized, not bundled
+- Always branch from `develop` for new work, never from `main` (unless hotfix)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,46 @@ Zustand stores in `src/renderer/store/`. Config data lives in electron-store (ac
 ### Path Alias
 `@/` maps to `src/renderer/` (configured in `electron.vite.config.ts`).
 
+## Git Branching Strategy (Git Flow)
+
+### Primary Branches
+
+- **`main`** -- Production-ready releases. Always stable and tagged with `vX.Y.Z`.
+- **`develop`** -- Integration branch. All feature work branches from here and merges back here.
+
+### Supporting Branch Prefixes
+
+| Prefix | Branch From | Merge Into | Example |
+|--------|-------------|------------|---------|
+| `feat/` | `develop` | `develop` | `feat/voice-trigger-editing` |
+| `fix/` | `develop` | `develop` | `fix/audio-recording-crash` |
+| `refactor/` | `develop` | `develop` | `refactor/extract-audio-utility` |
+| `docs/` | `develop` | `develop` | `docs/update-api-guide` |
+| `release/vX.Y.Z` | `develop` | `main` + `develop` | `release/v1.2.0` |
+| `hotfix/` | `main` | `main` + `develop` | `hotfix/critical-crash` |
+
+### Workflow
+
+1. Branch from `develop`: `git checkout -b feat/my-feature develop`
+2. Commit with conventional messages: `feat: add feature`, `fix: resolve bug`
+3. Open PR targeting `develop`
+4. After review, merge into `develop` (delete feature branch)
+5. For releases: `release/vX.Y.Z` from `develop` -> merge into `main`, tag, merge back to `develop`
+6. For hotfixes: `hotfix/description` from `main` -> merge into both `main` and `develop`
+
+### Commit Message Format
+
+`type: short description`
+
+Types: `feat`, `fix`, `refactor`, `docs`, `chore`, `style`, `test`, `perf`
+
+### Rules
+
+- Never force-push to `main` or `develop`
+- Always open a PR -- no direct pushes to `main` or `develop`
+- Run `npm run typecheck && npm run lint` before pushing
+- Tag every production release on `main`
+
 ## Common Pitfalls
 
 - Do not use `any` -- the linter will warn
@@ -125,3 +165,5 @@ Zustand stores in `src/renderer/store/`. Config data lives in electron-store (ac
 - Overlay windows are frameless and transparent -- test visual changes in all overlay contexts
 - API keys are stored in electron-store; never log or expose them
 - The main process externalizes `better-sqlite3` -- it must be a native module, not bundled
+- Always branch from `develop` for new work, never from `main` (unless hotfix)
+- Delete feature branches after merge to keep the repo clean

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,35 +96,46 @@ src/
 
 ## Making Changes
 
-### Workflow
+### Workflow (Git Flow)
+
+This project uses **Git Flow**. The `develop` branch is the integration branch for all new work. The `main` branch is reserved for production releases.
 
 1. Fork the repository
-2. Create a feature branch from `main`: `git checkout -b feat/my-feature`
+2. Create a feature branch from `develop`: `git checkout -b feat/my-feature develop`
 3. Make your changes
 4. Run checks: `npm run typecheck && npm run lint`
 5. Commit with a clear message (see below)
-6. Push and open a Pull Request
+6. Push and open a Pull Request **targeting `develop`**
 
 ### Branch Naming
 
-- `feat/description` -- new features
-- `fix/description` -- bug fixes
-- `refactor/description` -- code refactoring
-- `docs/description` -- documentation changes
+| Prefix | Purpose | Branch From | Merge Into |
+|--------|---------|-------------|------------|
+| `feat/` | New features | `develop` | `develop` |
+| `fix/` | Bug fixes | `develop` | `develop` |
+| `refactor/` | Code refactoring | `develop` | `develop` |
+| `docs/` | Documentation changes | `develop` | `develop` |
+| `hotfix/` | Urgent production fixes | `main` | `main` + `develop` |
+| `release/vX.Y.Z` | Release preparation | `develop` | `main` + `develop` |
 
-### Commit Messages
+### Commit Messages (Conventional Commits)
 
-Use clear, descriptive commit messages:
+Format: `type: short description`
 
 ```
 feat: add speech-to-text provider selection
 fix: resolve clipboard race condition on macOS
 refactor: extract shared formatting utilities
 docs: update README with new project structure
+chore: bump electron to v33.2
+perf: optimize overlay window preloading
 ```
+
+Types: `feat`, `fix`, `refactor`, `docs`, `chore`, `style`, `test`, `perf`
 
 ## Pull Request Guidelines
 
+- Open PRs against `develop` (not `main`)
 - Keep PRs focused on a single change
 - Include a clear description of what and why
 - Reference any related issues

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-lightgrey.svg" alt="Platform" />
   <a href="https://www.electronjs.org/"><img src="https://img.shields.io/badge/Electron-33+-47848F.svg" alt="Electron" /></a>
   <a href="https://react.dev/"><img src="https://img.shields.io/badge/React-19-61DAFB.svg" alt="React" /></a>
+  <a href="https://github.com/sponsors/zeyadelosherey"><img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink.svg" alt="Sponsor" /></a>
 </p>
 
 <p align="center">
@@ -211,6 +212,28 @@ This project includes configuration files for AI coding assistants so they can u
 | [Cursor](https://cursor.com) | [`.cursor/rules/`](.cursor/rules/) | Project rules for Cursor AI (architecture, coding standards, patterns) |
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | [`CLAUDE.md`](CLAUDE.md) | Project context for Claude Code CLI agent |
 | [OpenAI Codex](https://openai.com/codex) | [`CODEX.md`](CODEX.md) | Project context for OpenAI Codex agent |
+| [GitHub Copilot](https://github.com/features/copilot) | [`.github/copilot-instructions.md`](.github/copilot-instructions.md) | Project context for GitHub Copilot |
+
+---
+
+## Sponsor TapWisper
+
+TapWisper is free and open source. If you find it useful, please consider supporting its development:
+
+### Individual Supporters
+
+You can sponsor the project through GitHub Sponsors -- every contribution helps keep the project maintained and growing:
+
+> **[Become a Sponsor on GitHub](https://github.com/sponsors/zeyadelosherey)**
+
+### Corporate Sponsorship
+
+If your company uses TapWisper and would like to sponsor the project, partner on features, or discuss enterprise support, we'd love to hear from you:
+
+- **Email**: [support@tapwisper.ai](mailto:support@tapwisper.ai)
+- **GitHub Discussions**: [Start a conversation](https://github.com/zeyadelosherey/tapwisper-desktop/discussions)
+
+Corporate sponsors get visibility on this README and priority feature discussions.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add GitHub Sponsors funding configuration and sponsor badge to README
- Add sponsorship section (individual + corporate) to README
- Add GitHub Copilot instructions file for GPT-based assistants
- Document Git Flow branching strategy across all AI agent config files (Cursor rules, CLAUDE.md, Copilot instructions)
- Update CONTRIBUTING.md workflow to use `develop` as the base branch
- Update PR template with branch type labels and target branch section

## Changes

### New Files
- `.github/FUNDING.yml` -- enables the GitHub Sponsor button on the repo
- `.github/copilot-instructions.md` -- project context for GitHub Copilot / GPT assistants

### Updated Files
- `README.md` -- sponsor badge, sponsorship section, Copilot entry in AI Agent Guidelines table
- `CLAUDE.md` -- Git Flow branching strategy section
- `.cursor/rules/coding-standards.mdc` -- expanded Git conventions into full Git Flow docs
- `CONTRIBUTING.md` -- workflow updated to branch from `develop`, added all branch prefixes
- `.github/PULL_REQUEST_TEMPLATE.md` -- added branch type labels and target branch section

## Type of Change

- [x] New feature
- [x] Documentation update

## Target Branch

- [x] `develop` (features, fixes, refactors, docs)

## Checklist

- [x] Branch follows naming convention (`feat/sponsorship-and-git-flow-docs`)
- [x] Commit messages follow conventional format (`feat: ...`)
- [x] My code follows the project coding standards
- [x] I have updated documentation if needed

Made with [Cursor](https://cursor.com)