### PR TITLE
feat: add OpenAI Whisper as a transcription provider

### DIFF
--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -14,7 +14,7 @@ export interface TriggerEntry {
 export interface AppConfig {
   // AI Provider settings
   aiProvider: 'gemini' | 'together' | 'openai' | 'claude'
-  voiceProvider: 'whisper' | 'soniox'
+  voiceProvider: 'whisper' | 'openai-whisper' | 'soniox'
 
   // API Keys
   apiKeys: {
@@ -36,6 +36,7 @@ export interface AppConfig {
   // Voice Models
   voiceModels: {
     whisper: string
+    'openai-whisper': string
     soniox: string
   }
 
@@ -109,6 +110,7 @@ const defaultConfig: AppConfig = {
 
   voiceModels: {
     whisper: 'openai/whisper-large-v3',
+    'openai-whisper': 'whisper-1',
     soniox: 'soniox-stt-async-v3'
   },
 

--- a/src/renderer/constants/providers.ts
+++ b/src/renderer/constants/providers.ts
@@ -3,4 +3,4 @@
  */
 
 export type LLMProvider = 'gemini' | 'together' | 'openai' | 'claude'
-export type VoiceProvider = 'whisper' | 'soniox'
+export type VoiceProvider = 'whisper' | 'openai-whisper' | 'soniox'

--- a/src/renderer/pages/settings.tsx
+++ b/src/renderer/pages/settings.tsx
@@ -98,6 +98,7 @@ const PROVIDER_LOGOS: Record<string, (props: { className?: string }) => JSX.Elem
   claude: ClaudeLogo,
   together: TogetherLogo,
   whisper: WhisperLogo,
+  'openai-whisper': OpenAILogo,
   soniox: SonioxLogo
 }
 
@@ -107,7 +108,8 @@ const PROVIDER_LOGO_IMAGES: Partial<Record<string, string>> = {
   openai: openaiLogo,
   claude: claudeLogo,
   together: togetherLogo,
-  whisper: togetherLogo, // Together Whisper — use Together logo
+  whisper: togetherLogo,
+  'openai-whisper': openaiLogo,
   soniox: sonioxLogo
 }
 
@@ -120,6 +122,7 @@ const LLM_PROVIDERS: { id: LLMProvider; label: string; shortLabel: string; color
 
 const VOICE_PROVIDERS: { id: VoiceProvider; label: string; shortLabel: string; description: string; color: string }[] = [
   { id: 'whisper', label: 'Together Whisper', shortLabel: 'Whisper', description: 'Whisper Large v3 via Together AI', color: '#10A37F' },
+  { id: 'openai-whisper', label: 'OpenAI Whisper', shortLabel: 'OpenAI', description: 'Whisper & GPT-4o Transcribe via OpenAI', color: '#412991' },
   { id: 'soniox', label: 'Soniox', shortLabel: 'Soniox', description: 'Soniox STT Async v3', color: '#7EB6E0' }
 ]
 
@@ -179,6 +182,11 @@ const VOICE_PROVIDER_MODELS: Record<VoiceProvider, { id: string; label: string; 
     { id: 'openai/whisper-large-v3', label: 'Whisper Large v3', description: 'Best accuracy' },
     { id: 'mistralai/Voxtral-Mini-3B-2507', label: 'Voxtral Mini 3B', description: 'Fast multilingual STT' }
   ],
+  'openai-whisper': [
+    { id: 'whisper-1', label: 'Whisper-1', description: 'Reliable, multilingual' },
+    { id: 'gpt-4o-transcribe', label: 'GPT-4o Transcribe', description: 'Highest quality' },
+    { id: 'gpt-4o-mini-transcribe', label: 'GPT-4o Mini Transcribe', description: 'Fast & affordable' }
+  ],
   soniox: [
     { id: 'soniox-stt-async-v3', label: 'Soniox STT Async v3', description: 'Real-time streaming' }
   ]
@@ -193,6 +201,7 @@ const DEFAULT_MODELS: Record<LLMProvider, string> = {
 
 const DEFAULT_VOICE_MODELS: Record<VoiceProvider, string> = {
   whisper: 'openai/whisper-large-v3',
+  'openai-whisper': 'whisper-1',
   soniox: 'soniox-stt-async-v3'
 }
 
@@ -205,12 +214,14 @@ const LLM_API_KEY_LABELS: Record<LLMProvider, string> = {
 
 const VOICE_API_KEY_LABELS: Record<VoiceProvider, string> = {
   whisper: 'Together AI API Key',
+  'openai-whisper': 'OpenAI API Key',
   soniox: 'Soniox API Key'
 }
 
-/** Which API key ID to use for a voice provider (whisper shares together's key) */
+/** Which API key ID to use for a voice provider (whisper shares together's key, openai-whisper shares openai's key) */
 const VOICE_API_KEY_ID: Record<VoiceProvider, string> = {
   whisper: 'together',
+  'openai-whisper': 'openai',
   soniox: 'soniox'
 }
 
@@ -944,7 +955,7 @@ export function Settings(): JSX.Element {
               <h2 className="text-xs font-semibold text-theme-text-tertiary uppercase tracking-wider mb-3">
                 {t('settings.selectProvider', 'Select Provider')}
               </h2>
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-3 gap-2">
                 {VOICE_PROVIDERS.map((provider) => {
                   const LogoComponent = PROVIDER_LOGOS[provider.id]
                   const logoImage = PROVIDER_LOGO_IMAGES[provider.id]
@@ -1091,6 +1102,11 @@ export function Settings(): JSX.Element {
                 {selectedVoice === 'whisper' && (
                   <p className="text-[10px] text-theme-text-muted mt-2 italic">
                     {t('settings.whisperSharesKey', 'Whisper uses the same API key as Together AI.')}
+                  </p>
+                )}
+                {selectedVoice === 'openai-whisper' && (
+                  <p className="text-[10px] text-theme-text-muted mt-2 italic">
+                    {t('settings.openaiWhisperSharesKey', 'OpenAI Whisper uses the same API key as OpenAI.')}
                   </p>
                 )}
               </div>

--- a/src/renderer/services/ai-router.ts
+++ b/src/renderer/services/ai-router.ts
@@ -2,7 +2,7 @@ import { processWithGemini } from './gemini'
 import { processWithTogether } from './together'
 import { processWithOpenAI } from './openai'
 import { processWithClaude } from './claude'
-import { transcribeWithWhisper } from './whisper'
+import { transcribeWithWhisper, transcribeWithOpenAIWhisper } from './whisper'
 import { transcribeWithSoniox } from './soniox'
 
 export type { LLMProvider, VoiceProvider } from '../constants/providers'
@@ -72,9 +72,13 @@ export async function transcribeAudio(
 ): Promise<TranscriptionResponse> {
   const config = await window.tapwisper.store.getAll() as any
   const provider: VoiceProvider = config.voiceProvider || 'whisper'
-  const apiKey = provider === 'whisper'
-    ? config.apiKeys?.together
-    : config.apiKeys?.soniox
+
+  const voiceApiKeyMap: Record<VoiceProvider, string> = {
+    whisper: 'together',
+    'openai-whisper': 'openai',
+    soniox: 'soniox'
+  }
+  const apiKey = config.apiKeys?.[voiceApiKeyMap[provider]] || ''
   const voiceModel = config.voiceModels?.[provider]
 
   if (!apiKey) {
@@ -84,6 +88,8 @@ export async function transcribeAudio(
   switch (provider) {
     case 'whisper':
       return transcribeWithWhisper(audioBlob, apiKey, language, voiceModel)
+    case 'openai-whisper':
+      return transcribeWithOpenAIWhisper(audioBlob, apiKey, language, voiceModel)
     case 'soniox':
       return transcribeWithSoniox(audioBlob, apiKey, language)
     default:

--- a/src/renderer/services/whisper.ts
+++ b/src/renderer/services/whisper.ts
@@ -1,22 +1,27 @@
 import type { TranscriptionResponse } from './ai-router'
 
-const DEFAULT_MODEL = 'openai/whisper-large-v3'
-const API_BASE = 'https://api.together.xyz/v1'
+const TOGETHER_API_BASE = 'https://api.together.xyz/v1'
+const OPENAI_API_BASE = 'https://api.openai.com/v1'
 
-export async function transcribeWithWhisper(
+const DEFAULT_TOGETHER_MODEL = 'openai/whisper-large-v3'
+const DEFAULT_OPENAI_MODEL = 'whisper-1'
+
+async function transcribeWithWhisperBase(
   audioBlob: Blob,
   apiKey: string,
-  language?: string,
-  model?: string
+  language: string | undefined,
+  model: string,
+  apiBase: string,
+  providerLabel: string
 ): Promise<TranscriptionResponse> {
   const formData = new FormData()
   formData.append('file', audioBlob, 'recording.wav')
-  formData.append('model', model || DEFAULT_MODEL)
+  formData.append('model', model)
   if (language) {
     formData.append('language', language)
   }
 
-  const response = await fetch(`${API_BASE}/audio/transcriptions`, {
+  const response = await fetch(`${apiBase}/audio/transcriptions`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${apiKey}`
@@ -26,14 +31,46 @@ export async function transcribeWithWhisper(
 
   if (!response.ok) {
     const error = await response.text()
-    throw new Error(`Whisper transcription error: ${response.status} - ${error}`)
+    throw new Error(`${providerLabel} transcription error: ${response.status} - ${error}`)
   }
 
   const data = await response.json()
 
   return {
     text: data.text?.trim() || '',
-    provider: 'whisper',
+    provider: providerLabel,
     duration: data.duration
   }
+}
+
+export async function transcribeWithWhisper(
+  audioBlob: Blob,
+  apiKey: string,
+  language?: string,
+  model?: string
+): Promise<TranscriptionResponse> {
+  return transcribeWithWhisperBase(
+    audioBlob,
+    apiKey,
+    language,
+    model || DEFAULT_TOGETHER_MODEL,
+    TOGETHER_API_BASE,
+    'whisper'
+  )
+}
+
+export async function transcribeWithOpenAIWhisper(
+  audioBlob: Blob,
+  apiKey: string,
+  language?: string,
+  model?: string
+): Promise<TranscriptionResponse> {
+  return transcribeWithWhisperBase(
+    audioBlob,
+    apiKey,
+    language,
+    model || DEFAULT_OPENAI_MODEL,
+    OPENAI_API_BASE,
+    'openai-whisper'
+  )
 }


### PR DESCRIPTION
## Summary

Closes #7 -- adds OpenAI as a third transcription provider alongside Together Whisper and Soniox.

Users who already have an OpenAI API key can now use it for speech-to-text without needing a separate Together AI account.

## Changes

- **`src/renderer/constants/providers.ts`** -- Added `'openai-whisper'` to `VoiceProvider` union
- **`src/main/store.ts`** -- Added `'openai-whisper'` to config type and defaults (`whisper-1`)
- **`src/renderer/services/whisper.ts`** -- Refactored into a shared base function parameterized by API base URL; added `transcribeWithOpenAIWhisper` export pointing at `api.openai.com`
- **`src/renderer/services/ai-router.ts`** -- Added `'openai-whisper'` routing with `apiKeys.openai` key mapping
- **`src/renderer/pages/settings.tsx`** -- Added OpenAI Whisper to all provider constants, logos, models (whisper-1, gpt-4o-transcribe, gpt-4o-mini-transcribe), 3-column grid, shared-key hint

## Key design decisions

- **API reuse**: OpenAI and Together use the same `/v1/audio/transcriptions` multipart endpoint format, so a single base function handles both
- **Key reuse**: OpenAI Whisper uses the existing `apiKeys.openai` field (same key as GPT) -- no new API key field needed
- **Models**: whisper-1, gpt-4o-transcribe, gpt-4o-mini-transcribe (verified against current OpenAI API docs)

## Test Plan

- [ ] Select OpenAI Whisper in Settings > Transcription
- [ ] Verify the OpenAI API key field appears and shows "uses same key as OpenAI" hint
- [ ] Record and transcribe with whisper-1 model
- [ ] Record and transcribe with gpt-4o-transcribe model
- [ ] Verify Together Whisper still works unchanged
- [ ] Verify Soniox still works unchanged

Made with [Cursor](https://cursor.com)