### PR TITLE
fix: prevent arch-mismatched native modules in macOS release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,24 @@ permissions:
 
 jobs:
   release-mac-arm64:
-    runs-on: macos-latest
+    runs-on: macos-latest # Apple Silicon (arm64)
+    env:
+      npm_config_arch: arm64
+      npm_config_target_arch: arm64
+      npm_config_target_platform: darwin
+      npm_config_runtime: electron
     steps:
       - uses: actions/checkout@v4
+
+      - name: Verify host architecture is arm64
+        run: |
+          set -e
+          HOST_ARCH=$(uname -m)
+          echo "Host arch: $HOST_ARCH"
+          if [ "$HOST_ARCH" != "arm64" ]; then
+            echo "::error::Expected arm64 host runner, got $HOST_ARCH"
+            exit 1
+          fi
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -37,19 +52,38 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Verify packaged native module architecture (arm64)
+        run: bash scripts/verify-app-arch.sh dist/mac-arm64 arm64
+
       - name: Upload macOS arm64 artifacts
         uses: actions/upload-artifact@v4
         with:
           name: macos-arm64-artifacts
           path: |
-            dist/*.dmg
-            dist/*.zip
+            dist/*-arm64.dmg
+            dist/*-arm64-mac.zip
           retention-days: 1
+          if-no-files-found: error
 
   release-mac-x64:
-    runs-on: macos-15-large
+    runs-on: macos-15-large # Intel x86_64
+    env:
+      npm_config_arch: x64
+      npm_config_target_arch: x64
+      npm_config_target_platform: darwin
+      npm_config_runtime: electron
     steps:
       - uses: actions/checkout@v4
+
+      - name: Verify host architecture is x86_64
+        run: |
+          set -e
+          HOST_ARCH=$(uname -m)
+          echo "Host arch: $HOST_ARCH"
+          if [ "$HOST_ARCH" != "x86_64" ]; then
+            echo "::error::Expected x86_64 host runner, got $HOST_ARCH"
+            exit 1
+          fi
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -73,14 +107,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Verify packaged native module architecture (x64)
+        run: bash scripts/verify-app-arch.sh dist/mac x64
+
       - name: Upload macOS x64 artifacts
         uses: actions/upload-artifact@v4
         with:
           name: macos-x64-artifacts
           path: |
-            dist/*.dmg
-            dist/*.zip
+            dist/*-x64.dmg
+            dist/*-x64-mac.zip
           retention-days: 1
+          if-no-files-found: error
 
   release-win:
     runs-on: windows-latest
@@ -116,6 +154,7 @@ jobs:
           path: |
             dist/*.exe
           retention-days: 1
+          if-no-files-found: error
 
   create-release:
     needs: [release-mac-arm64, release-mac-x64, release-win]

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -28,6 +28,8 @@ mac:
         - x64
         - arm64
   icon: build/icon.png
+  # Default artifactName applies to mac targets (including zip). dmg overrides below.
+  artifactName: ${name}-${version}-${arch}-mac.${ext}
 dmg:
   artifactName: ${name}-${version}-${arch}.${ext}
 win:

--- a/scripts/verify-app-arch.sh
+++ b/scripts/verify-app-arch.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Verify that all active-load native modules inside a packaged macOS .app
+# match the target architecture.
+#
+# Usage:
+#   bash scripts/verify-app-arch.sh <appOutDir> <target-arch>
+#
+# Examples:
+#   bash scripts/verify-app-arch.sh dist/mac        x64
+#   bash scripts/verify-app-arch.sh dist/mac-arm64  arm64
+#
+# Notes:
+#   - electron-builder writes x64 macOS builds to dist/mac and arm64 to dist/mac-arm64.
+#   - We deliberately skip cross-platform/cross-arch prebuild siblings (e.g. linux-*,
+#     win32-*, and the *opposite* darwin arch) because they are harmless fallbacks
+#     that node-gyp-build never selects on the user's machine.
+#   - We always require the matching darwin-${arch} prebuild + every build/Release
+#     and lib/binding/*-darwin-unknown-${arch} .node file to match the target arch.
+
+set -euo pipefail
+
+APP_OUT_DIR="${1:?usage: $0 <appOutDir> <target-arch>}"
+TARGET_ARCH="${2:?usage: $0 <appOutDir> <target-arch>}"
+
+case "$TARGET_ARCH" in
+  x64)   EXPECTED_FILE_ARCH="x86_64" ;;
+  arm64) EXPECTED_FILE_ARCH="arm64" ;;
+  *) echo "::error::Unsupported target arch: $TARGET_ARCH" >&2; exit 2 ;;
+esac
+
+APP_DIR=""
+if [ -d "$APP_OUT_DIR" ]; then
+  APP_DIR=$(find "$APP_OUT_DIR" -maxdepth 2 -type d -name "*.app" 2>/dev/null | head -n 1 || true)
+fi
+if [ -z "$APP_DIR" ] && [ -d dist ]; then
+  APP_DIR=$(find dist -maxdepth 3 -type d -name "*.app" 2>/dev/null | head -n 1 || true)
+fi
+if [ -z "$APP_DIR" ] || [ ! -d "$APP_DIR" ]; then
+  echo "::error::Could not locate packaged .app under $APP_OUT_DIR or dist/" >&2
+  exit 1
+fi
+
+echo "Verifying .app: $APP_DIR"
+echo "Target arch:    $TARGET_ARCH (expecting Mach-O '$EXPECTED_FILE_ARCH')"
+echo ""
+
+fail=0
+checked=0
+
+is_active_load_path() {
+  case "$1" in
+    */build/Release/*.node)                                     return 0 ;;
+    */build-tmp-napi-*/Release/*.node)                          return 0 ;;
+    */prebuilds/darwin-${TARGET_ARCH}/*.node)                   return 0 ;;
+    */lib/binding/napi-*-darwin-unknown-${TARGET_ARCH}/*.node)  return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_skippable_cross_target() {
+  case "$1" in
+    */prebuilds/linux-*/*.node)                                 return 0 ;;
+    */prebuilds/win32-*/*.node)                                 return 0 ;;
+    */prebuilds/darwin-*/*.node)                                return 0 ;;
+    */lib/binding/napi-*-linux-*/*.node)                        return 0 ;;
+    */lib/binding/napi-*-win32-*/*.node)                        return 0 ;;
+    */lib/binding/napi-*-darwin-unknown-*/*.node)               return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+while IFS= read -r f; do
+  desc=$(file -b "$f" || echo "unknown")
+  if is_active_load_path "$f"; then
+    if printf '%s' "$desc" | grep -qw "$EXPECTED_FILE_ARCH"; then
+      echo "  OK   [$TARGET_ARCH] $f"
+    else
+      echo "  FAIL [$TARGET_ARCH] $f -- $desc"
+      echo "::error::Native module $f is not $EXPECTED_FILE_ARCH (got: $desc)"
+      fail=1
+    fi
+    checked=$((checked + 1))
+  elif is_skippable_cross_target "$f"; then
+    echo "  skip (cross-target prebuild) $f"
+  else
+    if printf '%s' "$desc" | grep -qw "$EXPECTED_FILE_ARCH"; then
+      echo "  OK   [misc]   $f"
+    else
+      echo "  FAIL [misc]   $f -- $desc"
+      echo "::error::Native module $f is not $EXPECTED_FILE_ARCH (got: $desc)"
+      fail=1
+    fi
+    checked=$((checked + 1))
+  fi
+done < <(find "$APP_DIR" -name "*.node")
+
+echo ""
+echo "Checked $checked active-load .node files."
+
+if [ "$checked" -eq 0 ]; then
+  echo "::error::No active-load .node files were found in $APP_DIR -- this is unexpected."
+  exit 1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "::error::One or more native modules have the wrong architecture for target $TARGET_ARCH."
+  exit 1
+fi
+
+echo "All native modules verified for target $TARGET_ARCH."


### PR DESCRIPTION
## Summary

The previous x64 release was packaging **arm64** native modules into `TapWisper.app`, causing `dlopen` to fail at startup on every install of the x64 DMG with:

```
'/Applications/TapWisper.app/.../uiohook-napi/build/Release/uiohook_napi.node'
(mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64'))
```

This PR is a **hotfix** branched off `main` per the project's Git Flow rules, since users currently can't launch the x64 release at all.

## What changed

- **Lock each macOS job to a matching-arch runner and assert it.** `release-mac-arm64` runs on `macos-latest` (Apple Silicon) and `release-mac-x64` runs on `macos-15-large` (Intel). Each job runs `uname -m` and fails fast if GitHub silently changes a runner label.
- **Force the right native binaries during install.** Each macOS job sets `npm_config_arch`, `npm_config_target_arch`, `npm_config_target_platform=darwin`, and `npm_config_runtime=electron` so `prebuild-install` and `@electron/rebuild` cannot pull a cross-arch prebuilt binary.
- **Add `scripts/verify-app-arch.sh`** and run it after each macOS pack. It walks the packaged `.app` and fails the job if any **active-load** `.node` file is the wrong architecture. Active-load paths checked:
  - `build/Release/*.node`
  - `build-tmp-napi-*/Release/*.node`
  - `prebuilds/darwin-${target_arch}/*.node`
  - `lib/binding/napi-*-darwin-unknown-${target_arch}/*.node`
  Cross-platform / cross-arch prebuild siblings (`linux-*`, `win32-*`, the *opposite* `darwin-*`) are skipped because `node-gyp-build` never selects them.
- **Deterministic per-arch artifact names.** `electron-builder.yml` now sets `mac.artifactName: ${name}-${version}-${arch}-mac.${ext}` so the zip output is unambiguously per-arch (e.g. `tapwisper-desktop-1.1.1-x64-mac.zip` vs `-arm64-mac.zip`). Workflow upload globs are tightened to arch-tagged patterns with `if-no-files-found: error`.

## Validation

Exercised the verification script locally against a real `electron-builder --mac --x64 --dir` pack:

| Scenario | Result |
|---|---|
| Real x64 `.app` (correct) | 7 OK, 5 cross-target skips, exit 0 |
| arm64 `.node` injected into x64 `.app` (the original bug) | exit 1, `::error::` annotation |
| x86_64 `.node` injected into arm64 `.app` (inverse) | exit 1, `::error::` annotation |
| Missing `.app` entirely | exit 1, clean error message |

Also validated `release.yml` and `electron-builder.yml` parse cleanly with `js-yaml`, and `scripts/verify-app-arch.sh` passes `bash -n`.

## Test plan

- [ ] Merge to `main`
- [ ] Re-tag (e.g. `v1.1.2`) to trigger the release workflow
- [ ] Verify both `release-mac-arm64` and `release-mac-x64` jobs pass, including the new `Verify packaged native module architecture` step
- [ ] Download the x64 DMG on an Intel Mac (or Apple Silicon via Rosetta) and confirm TapWisper launches without the dlopen error
- [ ] Download the arm64 DMG on Apple Silicon and confirm TapWisper still launches cleanly
- [ ] After verification, merge `main` back into `develop` per Git Flow hotfix policy

Made with [Cursor](https://cursor.com)