### PR TITLE
release: v1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tapwisper-desktop",
   "productName": "TapWisper",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "TapWisper Desktop - Open-source, system-wide voice dictation with AI",
   "main": "./out/main/index.js",
   "author": "TapWisper",


### PR DESCRIPTION
## Summary

Cuts release **v1.1.2** off `main`, which already contains the macOS architecture-mismatch hotfix (#12).

This is purely a `package.json` version bump so:
1. The artifact filenames produced by `electron-builder` carry the correct `1.1.2` version
2. The `Release` workflow fires on the `v1.1.2` tag I'll push immediately after this PR merges

## Why v1.1.2

`v1.1.1` was the previous release where the x64 DMG was packaged with arm64 native modules. That tag's run already failed and can't be replayed cleanly, so the fix ships as v1.1.2.

## Test plan

After merge:

- [ ] Tag `v1.1.2` on `main` and push -- this triggers the `Release` workflow
- [ ] Confirm `release-mac-arm64` and `release-mac-x64` jobs both reach the new `Verify packaged native module architecture` step and pass it
- [ ] Confirm `create-release` publishes a GitHub Release with both `*-arm64.dmg` / `*-arm64-mac.zip` and `*-x64.dmg` / `*-x64-mac.zip` plus the Windows installer
- [ ] Spot-check the x64 DMG on an Intel Mac (or via Rosetta) -- should launch without the `dlopen` error from the screenshot in #12
- [ ] Sync `main` back into `develop` so `develop` picks up both the hotfix and the version bump

Made with [Cursor](https://cursor.com)