### PR TITLE
fix: pick free working runners and drop redundant npm_config env vars

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,7 @@ permissions:
 
 jobs:
   release-mac-arm64:
-    runs-on: macos-latest # Apple Silicon (arm64)
-    env:
-      npm_config_arch: arm64
-      npm_config_target_arch: arm64
-      npm_config_target_platform: darwin
-      npm_config_runtime: electron
+    runs-on: macos-latest # Apple Silicon (arm64) -- free runner
     steps:
       - uses: actions/checkout@v4
 
@@ -66,12 +61,9 @@ jobs:
           if-no-files-found: error
 
   release-mac-x64:
-    runs-on: macos-15-large # Intel x86_64
-    env:
-      npm_config_arch: x64
-      npm_config_target_arch: x64
-      npm_config_target_platform: darwin
-      npm_config_runtime: electron
+    # Free Intel x86_64 runner. macos-15-large is also Intel but is a paid larger runner;
+    # macos-13 stays available until GitHub's deprecation completes (~Dec 2026).
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
 
@@ -121,7 +113,11 @@ jobs:
           if-no-files-found: error
 
   release-win:
-    runs-on: windows-latest
+    # Pin to windows-2022 explicitly. windows-latest currently rolls toward
+    # windows-2025/vs2026 which the node-gyp version bundled by @electron/rebuild
+    # cannot detect -- get-windows then fails to rebuild with "Could not find
+    # any Visual Studio installation to use".
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tapwisper-desktop",
   "productName": "TapWisper",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "TapWisper Desktop - Open-source, system-wide voice dictation with AI",
   "main": "./out/main/index.js",
   "author": "TapWisper",


### PR DESCRIPTION
## Why

The v1.1.2 release failed on every job. Three independent root causes, none of which were detectable until the workflow actually ran on GitHub:

| Job | Failure | Root cause |
|-----|---------|-----------|
| `release-mac-x64` | 3s -- "recent account payments have failed or your spending limit needs to be increased" | `macos-15-large` is a **paid** larger runner; account billing failed. Same job failed identically on v1.1.1. |
| `release-mac-arm64` | npm ci aborted with "Empty target version is not supported if electron is the target" | I'd added `npm_config_runtime: electron` env var without a matching `npm_config_target`, which broke `get-windows`'s `node-pre-gyp install`. |
| `release-win` | postinstall: "Could not find any Visual Studio installation to use" | `windows-latest` now redirects to `windows-2025`/`vs2026` (per the run's own notice), which the `node-gyp` bundled by `@electron/rebuild` cannot detect. v1.1.1's Windows job ran on the older image and succeeded. |

## Fixes

- **`release-mac-x64`**: switch from `macos-15-large` (paid) to `macos-13` -- the **free** Intel runner. Stays usable until GitHub completes macOS 13 deprecation (~Dec 2026); after that we'll need to either pay for a larger runner or drop x64.
- **`release-mac-arm64`**: drop the entire `env: npm_config_*` block I introduced in #12. Each macOS job already runs on a host whose arch matches the build target, and `electron-builder install-app-deps` handles the Electron-targeted rebuild. The existing `uname -m` precheck plus `scripts/verify-app-arch.sh` post-build remain in place to catch any architecture leak.
- **`release-win`**: pin to `windows-2022` explicitly. v1.1.1's Windows build succeeded there, and it still ships a Visual Studio that the bundled node-gyp can detect.
- **`package.json`**: bump to **1.1.3** since `v1.1.1` and `v1.1.2` tags are already burned by the failed runs.

## Test plan

After merge:

- [ ] Tag `v1.1.3` on `main` and push
- [ ] Confirm all three matrix jobs (`release-mac-arm64`, `release-mac-x64`, `release-win`) pass
- [ ] Confirm `release-mac-arm64` reaches its `Verify packaged native module architecture (arm64)` step and passes it
- [ ] Confirm `release-mac-x64` reaches its `Verify packaged native module architecture (x64)` step and passes it
- [ ] Confirm `create-release` publishes a GitHub Release with both DMGs, both ZIPs, and the Windows installer
- [ ] Spot-check the x64 DMG on Intel/Rosetta -- should launch without the dlopen error
- [ ] Sync `main` back into `develop`

Made with [Cursor](https://cursor.com)