### PR TITLE
fix: stop double-rebuild that corrupts mac arm64 native modules

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -18,15 +18,15 @@ mac:
     NSMicrophoneUsageDescription: "TapWisper needs microphone access for voice dictation."
     NSAppleEventsUsageDescription: "TapWisper needs accessibility access for global shortcuts and text insertion."
   notarize: false
+  # Do NOT pin arch here. With multiple archs listed, electron-builder rebuilds
+  # native modules for every configured arch even when the CLI passes `--arm64`
+  # (or `--x64`), and the second rebuild overwrites better-sqlite3 in node_modules
+  # before the first .app is fully populated -- producing arch-mismatched binaries.
+  # Each release job in .github/workflows/release.yml drives the arch via the CLI
+  # flag, so leaving arch unset here lets CLI control take effect.
   target:
-    - target: dmg
-      arch:
-        - x64
-        - arm64
-    - target: zip
-      arch:
-        - x64
-        - arm64
+    - dmg
+    - zip
   icon: build/icon.png
   # Default artifactName applies to mac targets (including zip). dmg overrides below.
   artifactName: ${name}-${version}-${arch}-mac.${ext}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tapwisper-desktop",
   "productName": "TapWisper",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "TapWisper Desktop - Open-source, system-wide voice dictation with AI",
   "main": "./out/main/index.js",
   "author": "TapWisper",


### PR DESCRIPTION
## Why

The v1.1.3 `release-mac-arm64` CI job exposed a real bug -- and the `verify-app-arch.sh` step from #12 caught it correctly:

```
FAIL [arm64] dist/mac-arm64/.../better-sqlite3/build/Release/better_sqlite3.node
  -- Mach-O 64-bit bundle x86_64
```

Looking at the actual install/build log on CI:

```
@electron/rebuild arch=arm64
  preparing better-sqlite3 arch=arm64
  finished  better-sqlite3 arch=arm64
@electron/rebuild arch=x64       ← second rebuild during a --arm64 build!
  preparing better-sqlite3 arch=x64
  finished  better-sqlite3 arch=x64
```

Even though the workflow ran `electron-builder --mac --arm64`, `electron-builder` iterated over every arch listed in `mac.target[*].arch: [x64, arm64]` when rebuilding native modules. The second pass overwrote `node_modules/better-sqlite3/build/Release/better_sqlite3.node` -- which the first `.app`'s hardlink points at -- so `dist/mac-arm64/...` ended up shipping the x86_64 binary. The same hazard exists in the inverse direction.

## Fix

Drop the explicit `arch:` lists in `electron-builder.yml`:

```diff
   target:
-    - target: dmg
-      arch:
-        - x64
-        - arm64
-    - target: zip
-      arch:
-        - x64
-        - arm64
+    - dmg
+    - zip
```

Each Release job now drives arch via its CLI flag (`--arm64` or `--x64`), so `electron-builder` rebuilds and packages exactly one arch per job and there's no chance of cross-arch overwrite.

## Local validation

```
$ npx electron-builder --mac --x64 --dir
  ...
  • executing @electron/rebuild  arch=x64       (only one rebuild)
  • preparing better-sqlite3 arch=x64
  • finished  better-sqlite3 arch=x64
  • packaging  arch=x64                          (only one packaging)

$ bash scripts/verify-app-arch.sh dist/mac x64
  Checked 7 active-load .node files.
  All native modules verified for target x64.
```

Compare to the broken v1.1.3 run which logged two `@electron/rebuild` calls and two `packaging` steps inside a single `--mac --arm64` invocation.

Also bumps `package.json` to **1.1.4** (`v1.1.1`, `v1.1.2`, `v1.1.3` tags are all burned by the previous failed runs).

## Test plan

- [ ] Merge to `main`
- [ ] Tag `v1.1.4` on `main` and push -- triggers the `Release` workflow
- [ ] Confirm only **one** `@electron/rebuild` call appears in each `release-mac-*` job's log
- [ ] Confirm `Verify packaged native module architecture` passes for both `arm64` and `x64`
- [ ] Confirm `create-release` publishes both DMGs / ZIPs and the Windows installer
- [ ] Spot-check the x64 DMG on Intel/Rosetta -- launches without dlopen error
- [ ] Sync `main` back into `develop`

Made with [Cursor](https://cursor.com)